### PR TITLE
Adds support for 'flipped' configuration

### DIFF
--- a/ridgeback_control/CMakeLists.txt
+++ b/ridgeback_control/CMakeLists.txt
@@ -42,7 +42,6 @@ install(DIRECTORY config launch
 )
 
 if(CATKIN_ENABLE_TESTING)
-  # find_package(gtest REQUIRED)
   find_package(roslaunch REQUIRED)
   catkin_add_gtest(mecanum_drive_controller_test test/mecanum_drive_controller_test.cpp)
   target_link_libraries(mecanum_drive_controller_test mecanum_drive_controller ${catkin_LIBRARIES} gtest_main)

--- a/ridgeback_control/CMakeLists.txt
+++ b/ridgeback_control/CMakeLists.txt
@@ -42,7 +42,13 @@ install(DIRECTORY config launch
 )
 
 if(CATKIN_ENABLE_TESTING)
+  # find_package(gtest REQUIRED)
   find_package(roslaunch REQUIRED)
+  catkin_add_gtest(mecanum_drive_controller_test test/mecanum_drive_controller_test.cpp)
+  target_link_libraries(mecanum_drive_controller_test mecanum_drive_controller ${catkin_LIBRARIES} gtest_main)
+  catkin_add_gtest(speed_limiter_test test/speed_limiter_test.cpp)
+  target_link_libraries(speed_limiter_test mecanum_drive_controller ${catkin_LIBRARIES} gtest_main)
+
   roslaunch_add_file_check(launch/control.launch)
   roslaunch_add_file_check(launch/teleop.launch)
 endif()

--- a/ridgeback_control/include/mecanum_drive_controller/mecanum_drive_controller.h
+++ b/ridgeback_control/include/mecanum_drive_controller/mecanum_drive_controller.h
@@ -39,6 +39,7 @@
 #include <controller_interface/controller.h>
 #include <hardware_interface/joint_command_interface.h>
 #include <pluginlib/class_list_macros.h>
+#include <urdf/model.h>
 
 #include <nav_msgs/Odometry.h>
 #include <tf/tfMessage.h>
@@ -96,6 +97,22 @@ public:
    */
   void stopping(const ros::Time& time);
 
+  struct WheelVelocities
+  {
+    double w0_vel;
+    double w1_vel;
+    double w2_vel;
+    double w3_vel;
+  };
+
+  static WheelVelocities calculateIkNormal(double linX, double linY, double ang,
+                                           double wheels_radius, double wheels_a,
+                                           double wheels_b);
+
+  static WheelVelocities calculateIkFlipped(double linX, double linY, double ang,
+                                            double wheels_radius, double wheels_a,
+                                            double wheels_b);
+
 private:
   std::string name_;
 
@@ -120,6 +137,7 @@ private:
 
     Commands() : linX(0.0), linY(0.0), ang(0.0), stamp(0.0) {}
   };
+
   realtime_tools::RealtimeBuffer<Commands> command_;
   Commands command_struct_;
   ros::Subscriber sub_command_;
@@ -130,9 +148,11 @@ private:
   Odometry odometry_;
   geometry_msgs::TransformStamped odom_frame_;
 
-  /// Wheel radius (assuming it's the same for the left and right wheels):
   bool use_realigned_roller_joints_;
+  /// Selects which inverse kinematic model to use.
+  bool use_flipped_geometry_;
   double wheels_k_; // wheels geometric param used in mecanum wheels' ik
+  /// Wheel radius (assuming it's the same for the left and right wheels):
   double wheels_radius_;
   double wheel_separation_x_;
   double wheel_separation_y_;

--- a/ridgeback_control/package.xml
+++ b/ridgeback_control/package.xml
@@ -27,6 +27,7 @@
   <exec_depend>topic_tools</exec_depend>
 
   <test_depend>roslaunch</test_depend>
+  <test_depend>gtest</test_depend>
 
   <export>
     <controller_interface plugin="${prefix}/mecanum_drive_controller_plugins.xml"/>

--- a/ridgeback_control/src/mecanum_drive_controller.cpp
+++ b/ridgeback_control/src/mecanum_drive_controller.cpp
@@ -345,7 +345,7 @@ void MecanumDriveController::cmdVelCallback(const geometry_msgs::Twist& command)
 {
   if(isRunning())
   {
-    command_struct_.ang   = -command.angular.z; // HACK TO FIX CONTROL FOR DEMO -JDB
+    command_struct_.ang   = command.angular.z;
     command_struct_.linX  = command.linear.x;
     command_struct_.linY  = command.linear.y;
     command_struct_.stamp = ros::Time::now();

--- a/ridgeback_control/src/mecanum_drive_controller.cpp
+++ b/ridgeback_control/src/mecanum_drive_controller.cpp
@@ -206,9 +206,9 @@ MecanumDriveController::WheelVelocities MecanumDriveController::calculateIkFlipp
                                                                                    double wheels_b)
 {
   MecanumDriveController::WheelVelocities wheel_velocities;
-  // Do not rotate velocities
-  double vx = linX;
-  double vy = linY;
+  // Do not rotate but flip the velocities
+  double vx = -linX;
+  double vy = -linY;
 
   // Calculate the wheels geometric constant
   double wheels_k = std::sqrt(wheels_a * wheels_a + wheels_b * wheels_b) * sin(M_PI_4 - atan2(wheels_b, wheels_a));

--- a/ridgeback_control/src/mecanum_drive_controller.cpp
+++ b/ridgeback_control/src/mecanum_drive_controller.cpp
@@ -206,18 +206,18 @@ MecanumDriveController::WheelVelocities MecanumDriveController::calculateIkFlipp
                                                                                    double wheels_b)
 {
   MecanumDriveController::WheelVelocities wheel_velocities;
-  // Replaces the B matrix
-  double vx = linY;
-  double vy = -linX;
+  // Do not rotate velocities
+  double vx = linX;
+  double vy = linY;
 
   // Calculate the wheels geometric constant
   double wheels_k = std::sqrt(wheels_a * wheels_a + wheels_b * wheels_b) * sin(M_PI_4 - atan2(wheels_b, wheels_a));
   double k = sqrt(2)/2;
 
-  wheel_velocities.w0_vel = -(std::sqrt(2) / wheels_radius) * (k * vx + k * vy + wheels_k * ang);
-  wheel_velocities.w1_vel = -(std::sqrt(2) / wheels_radius) * (k * vx - k * vy + wheels_k * ang);
-  wheel_velocities.w2_vel = -(std::sqrt(2) / wheels_radius) * (-1 * k * vx - k * vy + wheels_k * ang);
-  wheel_velocities.w3_vel = -(std::sqrt(2) / wheels_radius) * (-1 * k * vx + k * vy + wheels_k * ang);
+  wheel_velocities.w0_vel = (std::sqrt(2) / wheels_radius) * (-1 * k * vx + k * vy + wheels_k * ang);
+  wheel_velocities.w1_vel = (std::sqrt(2) / wheels_radius) * (-1 * k * vx - k * vy + wheels_k * ang);
+  wheel_velocities.w2_vel = (std::sqrt(2) / wheels_radius) * (k * vx - k * vy + wheels_k * ang);
+  wheel_velocities.w3_vel = (std::sqrt(2) / wheels_radius) * (k * vx + k * vy + wheels_k * ang);
   return wheel_velocities;
 }
 

--- a/ridgeback_control/test/inverse_kinematics.m
+++ b/ridgeback_control/test/inverse_kinematics.m
@@ -1,0 +1,38 @@
+# Quick and dirty test of the inverse kinematics presented on the paper:
+# Modeling and Adaptive Control of an Omni-Mecanum-Wheeled Robot
+# Lih-Chang Lin, Hao-Yin Shih
+# http://dx.doi.org/10.4236/ica.2013.42021
+
+R = 0.1;
+b = 1;  # 1m from robot center to wheel center along Y axis
+a = 0.5; # 0.5cm from robot center to wheel center along X axis
+theta = pi/2;
+
+l = sqrt(a*a + b*b);
+wk = l*sin(pi/4-atan2(b, a));
+k = sqrt(2)/2;
+
+M = [k k wk; k -k wk; -k -k wk; -k k wk];
+B = [cos(theta) sin(theta) 0; - sin(theta) cos(theta) 0; 0 0 1];
+
+t = [1;0;0];
+v = -(sqrt(2)/R) * M * B * t;
+
+# To verify that B con be replaced by a velocity swap.
+t = [0;-1;0];
+v = -(sqrt(2)/R) * M * t;
+
+t = [0;1;0];
+v = -(sqrt(2)/R) * M * B * t;
+
+t = [0;0;1];
+v = -(sqrt(2)/R) * M * B * t;
+
+t = [0;0;-1];
+v = -(sqrt(2)/R) * M * B * t;
+
+# When theta = pi/2, B, rotates the velocities so that Vx -> Vy and Vy -> -Vx
+#      [0 1 0; * [Vx;  = [ Vy;
+#      -1 0 0;    Vy;     -Vx;
+#       0 0 1]    R]       R ]
+

--- a/ridgeback_control/test/mecanum_drive_controller_test.cpp
+++ b/ridgeback_control/test/mecanum_drive_controller_test.cpp
@@ -112,17 +112,17 @@ TEST(MecanumDriveControllerTest, calculateInverseKinematicFlippedConfigurationX)
   // Positive in x (Forward)
   MecanumDriveController::WheelVelocities velocities;
   velocities = MecanumDriveController::calculateIkFlipped(1, 0, 0, r, a, b);
-  EXPECT_DOUBLE_EQ(velocities.w0_vel, -10);
-  EXPECT_DOUBLE_EQ(velocities.w1_vel, -10);
-  EXPECT_DOUBLE_EQ(velocities.w2_vel, 10);
-  EXPECT_DOUBLE_EQ(velocities.w3_vel, 10);
-
-  // Negative in x (back)
-  velocities = MecanumDriveController::calculateIkFlipped(-1, 0, 0, r, a, b);
   EXPECT_DOUBLE_EQ(velocities.w0_vel, 10);
   EXPECT_DOUBLE_EQ(velocities.w1_vel, 10);
   EXPECT_DOUBLE_EQ(velocities.w2_vel, -10);
   EXPECT_DOUBLE_EQ(velocities.w3_vel, -10);
+
+  // Negative in x (back)
+  velocities = MecanumDriveController::calculateIkFlipped(-1, 0, 0, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, 10);
 }
 
 TEST(MecanumDriveControllerTest, calculateInverseKinematicFlippedConfigurationY)
@@ -134,17 +134,17 @@ TEST(MecanumDriveControllerTest, calculateInverseKinematicFlippedConfigurationY)
 
   // Positive in y (right)
   velocities = MecanumDriveController::calculateIkFlipped(0, 1, 0, r, a, b);
-  EXPECT_DOUBLE_EQ(velocities.w0_vel, 10);
-  EXPECT_DOUBLE_EQ(velocities.w1_vel, -10);
-  EXPECT_DOUBLE_EQ(velocities.w2_vel, -10);
-  EXPECT_DOUBLE_EQ(velocities.w3_vel, 10);
-
-  // Negative in y (left)
-  velocities = MecanumDriveController::calculateIkFlipped(0, -1, 0, r, a, b);
   EXPECT_DOUBLE_EQ(velocities.w0_vel, -10);
   EXPECT_DOUBLE_EQ(velocities.w1_vel, 10);
   EXPECT_DOUBLE_EQ(velocities.w2_vel, 10);
   EXPECT_DOUBLE_EQ(velocities.w3_vel, -10);
+
+  // Negative in y (left)
+  velocities = MecanumDriveController::calculateIkFlipped(0, -1, 0, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, 10);
 }
 
 TEST(MecanumDriveControllerTest, calculateInverseKinematicFlippedConfigurationRotations)

--- a/ridgeback_control/test/mecanum_drive_controller_test.cpp
+++ b/ridgeback_control/test/mecanum_drive_controller_test.cpp
@@ -39,7 +39,7 @@ TEST(MecanumDriveControllerTest, calculateInverseKinematicNormalConfiguration)
   double b = 0.5;
   double r = 0.1;
 
-  // Forward in x
+  // Positive in x
   MecanumDriveController::WheelVelocities velocities;
 
   velocities = MecanumDriveController::calculateIkNormal(1, 0, 0, r, a, b);
@@ -47,20 +47,20 @@ TEST(MecanumDriveControllerTest, calculateInverseKinematicNormalConfiguration)
   EXPECT_DOUBLE_EQ(velocities.w1_vel, 10);
   EXPECT_DOUBLE_EQ(velocities.w2_vel, 10);
   EXPECT_DOUBLE_EQ(velocities.w3_vel, 10);
-  // Backwards in x
+  // Negative in x
   velocities = MecanumDriveController::calculateIkNormal(-1, 0, 0, r, a, b);
   EXPECT_DOUBLE_EQ(velocities.w0_vel, -10);
   EXPECT_DOUBLE_EQ(velocities.w1_vel, -10);
   EXPECT_DOUBLE_EQ(velocities.w2_vel, -10);
   EXPECT_DOUBLE_EQ(velocities.w3_vel, -10);
 
-  // Forward in y
+  // Positive in y
   velocities = MecanumDriveController::calculateIkNormal(0, 1, 0, r, a, b);
   EXPECT_DOUBLE_EQ(velocities.w0_vel, -10);
   EXPECT_DOUBLE_EQ(velocities.w1_vel, 10);
   EXPECT_DOUBLE_EQ(velocities.w2_vel, -10);
   EXPECT_DOUBLE_EQ(velocities.w3_vel, 10);
-  // Backwards in y
+  // Negative in y
   velocities = MecanumDriveController::calculateIkNormal(0, -1, 0, r, a, b);
   EXPECT_DOUBLE_EQ(velocities.w0_vel, 10);
   EXPECT_DOUBLE_EQ(velocities.w1_vel, -10);
@@ -81,7 +81,7 @@ TEST(MecanumDriveControllerTest, calculateInverseKinematicNormalConfiguration)
   EXPECT_DOUBLE_EQ(velocities.w3_vel, -15);
 }
 
-TEST(MecanumDriveControllerTest, calculateInverseKinematicFlippedConfiguration)
+TEST(MecanumDriveControllerTest, calculateInverseKinematicFlippedConfigurationX)
 {
   // The robot design is:
 
@@ -109,29 +109,64 @@ TEST(MecanumDriveControllerTest, calculateInverseKinematicFlippedConfiguration)
   double b = 1;
   double r = 0.1;
 
-  // IK equation used:
-  // Forward in x
+  // Positive in x (Forward)
   MecanumDriveController::WheelVelocities velocities;
   velocities = MecanumDriveController::calculateIkFlipped(1, 0, 0, r, a, b);
-  EXPECT_DOUBLE_EQ(velocities.w0_vel, 10);
-  EXPECT_DOUBLE_EQ(velocities.w1_vel, -10);
-  EXPECT_DOUBLE_EQ(velocities.w2_vel, -10);
-  EXPECT_DOUBLE_EQ(velocities.w3_vel, 10);
-
-  // Forward in x
-  velocities = MecanumDriveController::calculateIkFlipped(0, 1, 0, r, a, b);
   EXPECT_DOUBLE_EQ(velocities.w0_vel, -10);
   EXPECT_DOUBLE_EQ(velocities.w1_vel, -10);
   EXPECT_DOUBLE_EQ(velocities.w2_vel, 10);
   EXPECT_DOUBLE_EQ(velocities.w3_vel, 10);
 
-  // Possitive rotation
+  // Negative in x (back)
+  velocities = MecanumDriveController::calculateIkFlipped(-1, 0, 0, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, -10);
+}
+
+TEST(MecanumDriveControllerTest, calculateInverseKinematicFlippedConfigurationY)
+{
+  double a = 0.5;
+  double b = 1;
+  double r = 0.1;
+  MecanumDriveController::WheelVelocities velocities;
+
+  // Positive in y (right)
+  velocities = MecanumDriveController::calculateIkFlipped(0, 1, 0, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, 10);
+
+  // Negative in y (left)
+  velocities = MecanumDriveController::calculateIkFlipped(0, -1, 0, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, -10);
+}
+
+TEST(MecanumDriveControllerTest, calculateInverseKinematicFlippedConfigurationRotations)
+{
+  double a = 0.5;
+  double b = 1;
+  double r = 0.1;
+  MecanumDriveController::WheelVelocities velocities;
+
+  // Positive rotation (clockwise)
   velocities = MecanumDriveController::calculateIkFlipped(0, 0, 1, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, -5);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, -5);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, -5);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, -5);
+
+  // Negative rotation (counter closwise)
+  velocities = MecanumDriveController::calculateIkFlipped(0, 0, -1, r, a, b);
   EXPECT_DOUBLE_EQ(velocities.w0_vel, 5);
   EXPECT_DOUBLE_EQ(velocities.w1_vel, 5);
   EXPECT_DOUBLE_EQ(velocities.w2_vel, 5);
   EXPECT_DOUBLE_EQ(velocities.w3_vel, 5);
-
 }
 
 }

--- a/ridgeback_control/test/mecanum_drive_controller_test.cpp
+++ b/ridgeback_control/test/mecanum_drive_controller_test.cpp
@@ -1,0 +1,138 @@
+#include <mecanum_drive_controller/mecanum_drive_controller.h>
+#include <gtest/gtest.h>
+
+namespace mecanum_drive_controller {
+namespace {
+
+// Normal configuration: wheel main rotation axis is aligned with the robot's y axis
+// Flipped configuration: wheel main rotation axis is aligned with the robot's x axis
+
+TEST(MecanumDriveControllerTest, calculateInverseKinematicNormalConfiguration)
+{
+  // IK equation used:
+  // v_0 = 1/R * V_x - V_y - w*(wheel_k)
+  // v_1 = 1/R * V_x + V_y - w*(wheel_k)
+  // v_2 = 1/R * V_x - V_y + w*(wheel_k)
+  // v_3 = 1/R * V_x + V_y + w*(wheel_k)
+
+  // The robot design is:
+
+  //             ^ (y)
+  //      //     +     \\
+  //      -------|-------
+  //      |      b      |
+  //      |      |      |
+  //      |      o---a--+---> (x)
+  //      |             |
+  //      |             |
+  //      ---------------
+  //      \\           //
+  //
+  // where:
+  //   the // and \\ outside of the robot body mark the rollers orientation.
+  //   a = distance from robot center (o) to wheel center along Y axis.
+  //   b = distance from robot center (o) to wheel center along X axis.
+  //   r = main wheel radius.
+
+  // In our example:
+  double a = 1;
+  double b = 0.5;
+  double r = 0.1;
+
+  // Forward in x
+  MecanumDriveController::WheelVelocities velocities;
+
+  velocities = MecanumDriveController::calculateIkNormal(1, 0, 0, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, 10);
+  // Backwards in x
+  velocities = MecanumDriveController::calculateIkNormal(-1, 0, 0, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, -10);
+
+  // Forward in y
+  velocities = MecanumDriveController::calculateIkNormal(0, 1, 0, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, 10);
+  // Backwards in y
+  velocities = MecanumDriveController::calculateIkNormal(0, -1, 0, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, -10);
+
+  // Positive rotation
+  velocities = MecanumDriveController::calculateIkNormal(0, 0, 1, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, -15);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, -15);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, 15);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, 15);
+  // Negative rotation
+  velocities = MecanumDriveController::calculateIkNormal(0, 0, -1, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, 15);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, 15);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, -15);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, -15);
+}
+
+TEST(MecanumDriveControllerTest, calculateInverseKinematicFlippedConfiguration)
+{
+  // The robot design is:
+
+  //                   ^ (x)
+  //          \\       |        //
+  //          ---------+---------
+  //          |        |        |
+  //          |        a        |
+  //          |        |        |
+  //   (y) <--+--b-----o        |
+  //          |                 |
+  //          |                 |
+  //          |                 |
+  //          -------------------
+  //          //               \\
+
+  // where:
+  //   the // and \\ outside of the robot body mark the rollers orientation.
+  //   a = distance from robot center (o) to wheel center along Y axis.
+  //   b = distance from robot center (o) to wheel center along X axis.
+  //   r = main wheel radius.
+
+  // In our example:
+  double a = 0.5;
+  double b = 1;
+  double r = 0.1;
+
+  // IK equation used:
+  // Forward in x
+  MecanumDriveController::WheelVelocities velocities;
+  velocities = MecanumDriveController::calculateIkFlipped(1, 0, 0, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, 10);
+
+  // Forward in x
+  velocities = MecanumDriveController::calculateIkFlipped(0, 1, 0, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, -10);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, 10);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, 10);
+
+  // Possitive rotation
+  velocities = MecanumDriveController::calculateIkFlipped(0, 0, 1, r, a, b);
+  EXPECT_DOUBLE_EQ(velocities.w0_vel, 5);
+  EXPECT_DOUBLE_EQ(velocities.w1_vel, 5);
+  EXPECT_DOUBLE_EQ(velocities.w2_vel, 5);
+  EXPECT_DOUBLE_EQ(velocities.w3_vel, 5);
+
+}
+
+}
+}

--- a/ridgeback_control/test/speed_limiter_test.cpp
+++ b/ridgeback_control/test/speed_limiter_test.cpp
@@ -1,0 +1,80 @@
+#include <mecanum_drive_controller/speed_limiter.h>
+#include <gtest/gtest.h>
+
+namespace mecanum_drive_controller {
+namespace {
+
+TEST(SpeedLimiterTest, noLimitsEnabledDoesNotClamp)
+{
+  // By default, no limits are set.
+  SpeedLimiter speed_limiter;
+  double fast_velocity = 100.0;
+  double timestep = 20;
+  double initial_velocity = fast_velocity;
+  double current_velocity = fast_velocity + 10;
+  speed_limiter.limit_velocity(initial_velocity);
+  EXPECT_DOUBLE_EQ(fast_velocity, initial_velocity);
+  speed_limiter.limit_acceleration(current_velocity, initial_velocity, timestep);
+  EXPECT_DOUBLE_EQ(fast_velocity+10, current_velocity);
+}
+
+TEST(SpeedLimiterTest, velocityShouldBeLimited)
+{
+  // Min vel 1.0, max vel 10.0 no acceleration limit.
+  double max_velocity = 10.0;
+  double min_velocity = 1.0;
+  SpeedLimiter speed_limiter(true, false, min_velocity, max_velocity, 0.0, 0.0);
+  double velocity = 100.0;
+  speed_limiter.limit_velocity(velocity);
+  EXPECT_DOUBLE_EQ(max_velocity, velocity);
+
+  velocity = 0.1;
+  speed_limiter.limit_velocity(velocity);
+  EXPECT_DOUBLE_EQ(min_velocity, velocity);
+
+  velocity = 5.0;
+  speed_limiter.limit_velocity(velocity);
+  EXPECT_DOUBLE_EQ(5.0, velocity);
+}
+
+TEST(SpeedLimiterTest, accelerationShouldBeLimited)
+{
+  // Min vel 1.0, max vel 10.0 no acceleration limit.
+  double max_acceleration = 10.0;
+  double min_acceleration = 1.0;
+  SpeedLimiter speed_limiter(false, true, 0.0, 0.0, min_acceleration, max_acceleration);
+  double initial_velocity = 1.0;
+  double current_velocity = 20.0; // more than the max acceleration.
+  double time_step = 1.0;
+  speed_limiter.limit_acceleration(current_velocity, initial_velocity, time_step);
+  EXPECT_DOUBLE_EQ(initial_velocity+max_acceleration*time_step, current_velocity);
+
+  current_velocity = 1.0; // less than min acceleration.
+  speed_limiter.limit_acceleration(current_velocity, initial_velocity, time_step);
+  EXPECT_DOUBLE_EQ(initial_velocity + min_acceleration * time_step, current_velocity);
+
+  current_velocity = 5.0; // should be within acceptable limits
+  speed_limiter.limit_acceleration(current_velocity, initial_velocity, time_step);
+  EXPECT_DOUBLE_EQ(5, current_velocity);
+}
+
+TEST(SpeedLimiterTest, bothShouldBeLimited)
+{
+  double max_velocity = 20.0;
+  double min_velocity = 1.0;
+  double max_acceleration = 10.0;
+  double min_acceleration = 1.0;
+
+  SpeedLimiter speed_limiter(true, true, min_velocity, max_velocity,
+                             min_acceleration, max_acceleration);
+
+  double initial_velocity = 1.0;
+  double timestep = 1.0;
+  double current_velocity = 30;
+  speed_limiter.limit(current_velocity, initial_velocity, timestep);
+  // 30 will be limited to 20, then max acceleration will limit dv to 10
+  EXPECT_DOUBLE_EQ(max_acceleration*timestep + initial_velocity, current_velocity);
+}
+
+}
+}


### PR DESCRIPTION
Closes https://github.com/iron-ox/iron_ox/issues/599

Assumes that the mover geometry is:
![screenshot from 2018-10-16 15-10-03](https://user-images.githubusercontent.com/764126/47018829-eb9a8d80-d155-11e8-9506-3901f513a399.png)

The file `mecanum_drive_controller_test.cpp ` contains some more explications about the original IK model the controller uses and the new one that this patch adds, as well as some example outputs that were calculated with octave and then reproduced with the cpp code. Note that the new IK respects the 'all wheels rotating forward then the robot rotates'.

I added the super simple octave code that I used just for completeness.