### PR TITLE
Add support for flipped forward kinematics

### DIFF
--- a/ridgeback_control/CMakeLists.txt
+++ b/ridgeback_control/CMakeLists.txt
@@ -47,6 +47,8 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(mecanum_drive_controller_test mecanum_drive_controller ${catkin_LIBRARIES} gtest_main)
   catkin_add_gtest(speed_limiter_test test/speed_limiter_test.cpp)
   target_link_libraries(speed_limiter_test mecanum_drive_controller ${catkin_LIBRARIES} gtest_main)
+  catkin_add_gtest(odometry_test test/odometry_test.cpp)
+  target_link_libraries(odometry_test mecanum_drive_controller ${catkin_LIBRARIES} gtest_main)
 
   roslaunch_add_file_check(launch/control.launch)
   roslaunch_add_file_check(launch/teleop.launch)

--- a/ridgeback_control/include/mecanum_drive_controller/odometry.h
+++ b/ridgeback_control/include/mecanum_drive_controller/odometry.h
@@ -61,6 +61,17 @@ class Odometry
 {
 public:
 
+  struct BodyVelocities {
+    double linearX;
+    double linearY;
+    double angular;
+
+    BodyVelocities() {};
+
+    BodyVelocities(double linearX, double linearY, double angular):
+      linearX(linearX), linearY(linearY), angular(angular) {}
+  };
+
   /// Integration function, used to integrate the odometry:
   typedef boost::function<void(double, double, double)> IntegrationFunction;
 
@@ -156,7 +167,17 @@ public:
    * \param wheels_k       Wheels geometric param (used in mecanum wheels' ik) [m]
    * \param wheels_radius  Wheels radius [m]
    */
-  void setWheelsParams(double wheels_k, double wheels_radius);
+  void setWheelsParams(double wheels_a, double wheels_b, double wheels_radius);
+
+  void useFlippedGeometry(bool use_flipped_geometry);
+
+  static BodyVelocities calculateKinematicsNormal(double wheel0_vel, double wheel1_vel, double wheel2_vel,
+                                                  double wheel3_vel, double wheels_radius, double wheels_a,
+                                                  double wheels_b);
+
+  static BodyVelocities calculateKinematicsFlipped(double wheel0_vel, double wheel1_vel, double wheel2_vel,
+                                                   double wheel3_vel, double wheels_radius, double wheels_a,
+                                                   double wheels_b);
 
 private:
 
@@ -186,10 +207,12 @@ private:
   double angular_; // [rad/s]
 
   /// Wheels kinematic parameters [m]:
-  double wheels_k_;
+  double wheels_a_;
+  double wheels_b_;
   double wheels_radius_;
+  bool use_flipped_geometry_;
 
-  /// Rolling mean accumulators for the linar and angular velocities:
+  /// Rolling mean accumulators for the linear and angular velocities:
   size_t velocity_rolling_window_size_;
   RollingMeanAcc linearX_acc_;
   RollingMeanAcc linearY_acc_;

--- a/ridgeback_control/src/mecanum_drive_controller.cpp
+++ b/ridgeback_control/src/mecanum_drive_controller.cpp
@@ -206,6 +206,10 @@ MecanumDriveController::WheelVelocities MecanumDriveController::calculateIkFlipp
                                                                                    double wheels_radius, double wheels_a,
                                                                                    double wheels_b)
 {
+  // The inverse kinematics used are taken from:
+  // http://dx.doi.org/10.4236/ica.2013.42021
+  // And then changed to match the real output that we needed to move the robot
+  // properly.
   MecanumDriveController::WheelVelocities wheel_velocities;
   // Do not rotate but flip the velocities
   double vx = -linX;

--- a/ridgeback_control/src/mecanum_drive_controller.cpp
+++ b/ridgeback_control/src/mecanum_drive_controller.cpp
@@ -110,6 +110,7 @@ bool MecanumDriveController::init(hardware_interface::VelocityJointInterface* hw
 
   // Option use_flipped_geometry
   controller_nh.param("use_flipped_geometry", use_flipped_geometry_, use_flipped_geometry_);
+  odometry_.useFlippedGeometry(use_flipped_geometry_);
   ROS_INFO_STREAM_NAMED(name_, "Use the flipped geometry mode: " << use_flipped_geometry_ << ".");
 
   // Get joint names from the parameter server
@@ -499,7 +500,7 @@ bool MecanumDriveController::setWheelParamsFromUrdf(ros::NodeHandle& root_nh,
   ROS_INFO_STREAM("Wheel seperation in X: " << wheel_separation_x_);
   ROS_INFO_STREAM("Wheel seperation in Y: " << wheel_separation_y_);
   // Set wheel params for the odometry computation
-  odometry_.setWheelsParams(wheels_k_, wheels_radius_);
+  odometry_.setWheelsParams(wheel_separation_x_, wheel_separation_y_, wheels_radius_);
 
   return true;
 }

--- a/ridgeback_control/src/odometry.cpp
+++ b/ridgeback_control/src/odometry.cpp
@@ -109,6 +109,8 @@ Odometry::BodyVelocities Odometry::calculateKinematicsFlipped(double wheel0_vel,
                                                               double wheel3_vel, double wheels_radius, double wheels_a,
                                                               double wheels_b)
 {
+  // The formward kinetics model was obtained doing the pseudoinverse of the inverse kinematics
+  // model used for the flipped configuration.
   Odometry::BodyVelocities velocities;
   double wheels_k = std::sqrt(wheels_a * wheels_a + wheels_b * wheels_b) * sin(M_PI_4 - atan2(wheels_b, wheels_a));
   double k = sqrt(2) / 2;

--- a/ridgeback_control/src/odometry.cpp
+++ b/ridgeback_control/src/odometry.cpp
@@ -59,7 +59,8 @@ Odometry::Odometry(size_t velocity_rolling_window_size)
 , linearX_(0.0)
 , linearY_(0.0)
 , angular_(0.0)
-, wheels_k_(0.0)
+, wheels_a_(0.0)
+, wheels_b_(0.0)
 , wheels_radius_(0.0)
 , velocity_rolling_window_size_(velocity_rolling_window_size)
 , linearX_acc_(RollingWindow::window_size = velocity_rolling_window_size)
@@ -67,6 +68,11 @@ Odometry::Odometry(size_t velocity_rolling_window_size)
 , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
 , integrate_fun_(boost::bind(&Odometry::integrateExact, this, _1, _2, _3))
 {
+}
+
+void Odometry::useFlippedGeometry(bool use_flipped_geometry)
+{
+  use_flipped_geometry_ = use_flipped_geometry;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -81,6 +87,44 @@ void Odometry::init(const ros::Time& time)
   timestamp_ = time;
 }
 
+Odometry::BodyVelocities Odometry::calculateKinematicsNormal(double wheel0_vel, double wheel1_vel, double wheel2_vel,
+                                                             double wheel3_vel, double wheels_radius, double wheels_a,
+                                                             double wheels_b)
+{
+  /// Compute forward kinematics (i.e. compute mobile robot's body twist out of its wheels velocities):
+  /// NOTE: we use the IK of the mecanum wheels which we invert using a pseudo-inverse.
+  /// NOTE: in the diff drive the velocity is filtered out, but we prefer to return it raw and let the user perform
+  ///       post-processing at will. We prefer this way of doing as filtering introduces delay (which makes it
+  ///       difficult to interpret and compare behavior curves).
+  Odometry::BodyVelocities velocities;
+  double wheels_k = wheels_a + wheels_b;
+  velocities.linearX = 0.25 * wheels_radius * (wheel0_vel + wheel1_vel + wheel2_vel + wheel3_vel);
+  velocities.linearY = 0.25 * wheels_radius * (-wheel0_vel + wheel1_vel - wheel2_vel + wheel3_vel);
+  velocities.angular = 0.25 * wheels_radius / wheels_k * (-wheel0_vel - wheel1_vel + wheel2_vel + wheel3_vel);
+
+  return velocities;
+}
+
+Odometry::BodyVelocities Odometry::calculateKinematicsFlipped(double wheel0_vel, double wheel1_vel, double wheel2_vel,
+                                                              double wheel3_vel, double wheels_radius, double wheels_a,
+                                                              double wheels_b)
+{
+  Odometry::BodyVelocities velocities;
+  double wheels_k = std::sqrt(wheels_a * wheels_a + wheels_b * wheels_b) * sin(M_PI_4 - atan2(wheels_b, wheels_a));
+  double k = sqrt(2) / 2;
+
+  double A = wheels_radius / std::sqrt(2);
+
+  velocities.linearX = A * (wheels_k * wheel0_vel + wheels_k * wheel1_vel - wheels_k * wheel2_vel - wheels_k * wheel3_vel);
+  velocities.linearY = A * (-1 * wheels_k * wheel0_vel + wheels_k * wheel1_vel + wheels_k * wheel2_vel - wheels_k * wheel3_vel);
+  velocities.angular = A * (-1 * k * wheel0_vel - k * wheel1_vel - k * wheel2_vel - k * wheel3_vel);
+
+  velocities.linearX = -velocities.linearX;
+  velocities.linearY = -velocities.linearY;
+
+  return velocities;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 bool Odometry::update(double wheel0_vel, double wheel1_vel, double wheel2_vel, double wheel3_vel, const ros::Time &time)
 {
@@ -91,14 +135,16 @@ bool Odometry::update(double wheel0_vel, double wheel1_vel, double wheel2_vel, d
 
   timestamp_ = time;
 
-  /// Compute forward kinematics (i.e. compute mobile robot's body twist out of its wheels velocities):
-  /// NOTE: we use the IK of the mecanum wheels which we invert using a pseudo-inverse.
-  /// NOTE: in the diff drive the velocity is filtered out, but we prefer to return it raw and let the user perform
-  ///       post-processing at will. We prefer this way of doing as filtering introduces delay (which makes it
-  ///       difficult to interpret and compare behavior curves).
-  linearX_ = 0.25 * wheels_radius_              * ( wheel0_vel + wheel1_vel + wheel2_vel + wheel3_vel);
-  linearY_ = 0.25 * wheels_radius_              * (-wheel0_vel + wheel1_vel - wheel2_vel + wheel3_vel);
-  angular_ = 0.25 * wheels_radius_  / wheels_k_ * (-wheel0_vel - wheel1_vel + wheel2_vel + wheel3_vel);
+  BodyVelocities velocities;
+  if (use_flipped_geometry_) {
+    velocities = calculateKinematicsFlipped(wheel0_vel, wheel1_vel, wheel2_vel, wheel3_vel, wheels_radius_, wheels_a_, wheels_b_);
+  } else {
+    velocities = calculateKinematicsNormal(wheel0_vel, wheel1_vel, wheel2_vel, wheel3_vel, wheels_radius_, wheels_a_, wheels_b_);
+  }
+
+  linearX_ = velocities.linearX;
+  linearY_ = velocities.linearY;
+  angular_ = velocities.angular;
 
   /// Integrate odometry.
   integrate_fun_(linearX_ * dt, linearY_ * dt, angular_ * dt);
@@ -121,9 +167,10 @@ void Odometry::updateOpenLoop(double linearX, double linearY, double angular, co
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void Odometry::setWheelsParams(double wheels_k, double wheels_radius)
+void Odometry::setWheelsParams(double wheels_a, double wheels_b, double wheels_radius)
 {
-  wheels_k_ = wheels_k;
+  wheels_a_ = wheels_a;
+  wheels_b_ = wheels_b;
 
   wheels_radius_ = wheels_radius;
 }

--- a/ridgeback_control/test/inverse_kinematics.m
+++ b/ridgeback_control/test/inverse_kinematics.m
@@ -1,38 +1,123 @@
+unused = '';
 # Quick and dirty test of the inverse kinematics presented on the paper:
 # Modeling and Adaptive Control of an Omni-Mecanum-Wheeled Robot
 # Lih-Chang Lin, Hao-Yin Shih
 # http://dx.doi.org/10.4236/ica.2013.42021
 
-R = 0.1;
-b = 1;  # 1m from robot center to wheel center along Y axis
-a = 0.5; # 0.5cm from robot center to wheel center along X axis
-theta = pi/2;
+function paper_model()
+  R = 0.1;
+  b = 1;  # 1m from robot center to wheel center along Y axis
+  a = 0.5; # 0.5cm from robot center to wheel center along X axis
+  theta = pi/2;
 
-l = sqrt(a*a + b*b);
-wk = l*sin(pi/4-atan2(b, a));
-k = sqrt(2)/2;
+  l = sqrt(a*a + b*b);
+  wk = l*sin(pi/4-atan2(b, a));
+  k = sqrt(2)/2;
 
-M = [k k wk; k -k wk; -k -k wk; -k k wk];
-B = [cos(theta) sin(theta) 0; - sin(theta) cos(theta) 0; 0 0 1];
+  M = [k k wk; k -k wk; -k -k wk; -k k wk];
+  B = [cos(theta) sin(theta) 0; - sin(theta) cos(theta) 0; 0 0 1];
 
-t = [1;0;0];
-v = -(sqrt(2)/R) * M * B * t;
+  t = [1;0;0];
+  v = -(sqrt(2)/R) * M * B * t;
 
-# To verify that B con be replaced by a velocity swap.
-t = [0;-1;0];
-v = -(sqrt(2)/R) * M * t;
+  # To verify that B con be replaced by a velocity swap.
+  t = [0;-1;0];
+  v = -(sqrt(2)/R) * M * t;
 
-t = [0;1;0];
-v = -(sqrt(2)/R) * M * B * t;
+  t = [0;1;0];
+  v = -(sqrt(2)/R) * M * B * t;
 
-t = [0;0;1];
-v = -(sqrt(2)/R) * M * B * t;
+  t = [0;0;1];
+  v = -(sqrt(2)/R) * M * B * t;
 
-t = [0;0;-1];
-v = -(sqrt(2)/R) * M * B * t;
+  t = [0;0;-1];
+  v = -(sqrt(2)/R) * M * B * t;
 
-# When theta = pi/2, B, rotates the velocities so that Vx -> Vy and Vy -> -Vx
-#      [0 1 0; * [Vx;  = [ Vy;
-#      -1 0 0;    Vy;     -Vx;
-#       0 0 1]    R]       R ]
+  # When theta = pi/2, B, rotates the velocities so that Vx -> Vy and Vy -> -Vx
+  #      [0 1 0; * [Vx;  = [ Vy;
+  #      -1 0 0;    Vy;     -Vx;
+  #       0 0 1]    R]       R ]
+endfunction
 
+
+function wheel_velocities = mover_ik(body_velocities)
+  ## Experimentally tested on the robot and works.
+  R = 0.1;
+  b = 1;  # 1m from robot center to wheel center along Y axis
+  a = 0.5; # 0.5cm from robot center to wheel center along X axis
+  theta = pi;
+  l = sqrt(a*a + b*b);
+  wk = l*sin(pi/4-atan2(b, a));
+  k = sqrt(2)/2;
+
+  M = [-k k wk; -k -k wk; k -k wk; k k wk];
+  B = [cos(theta) sin(theta) 0; - sin(theta) cos(theta) 0; 0 0 1];
+
+  wheel_velocities = (sqrt(2)/R) * M * B * body_velocities
+endfunction
+
+
+function body_velocities = mover_fk(wheel_velocities)
+  R = 0.1;
+  b = 1;  # 1m from robot center to wheel center along Y axis
+  a = 0.5; # 0.5cm from robot center to wheel center along X axis
+  theta = pi;
+  l = sqrt(a*a + b*b);
+  wk = l*sin(pi/4-atan2(b, a));
+  k = sqrt(2)/2;
+
+  M = [-k k wk; -k -k wk; k -k wk; k k wk];
+  B = [cos(theta) sin(theta) 0; - sin(theta) cos(theta) 0; 0 0 1];
+
+  ## We need to use the pseudoinverse of the M matrix, as it is not a square matrix.
+  ## That means that the forward kinematic not always has a single solution.
+  ## Some wheel motions will render the system overdetermined and it will
+  ## produce the closes solution.
+
+  # M
+  # pinv(M)
+  # inv(B)
+  inverse_system = inv(B)*pinv(M);
+  body_velocities = R/sqrt(2) * inverse_system * wheel_velocities;
+endfunction
+
+
+## All convinations of body velocities should be able to
+## produce a set of wheel velocies and then be converted back to
+## body velocies.
+
+t = [1;0;0]
+mover_fk(mover_ik(t))
+
+t = [0;1;0]
+mover_fk(mover_ik(t))
+
+t = [0;0;1]
+mover_fk(mover_ik(t))
+
+t = [-1;0;0]
+mover_fk(mover_ik(t))
+
+t = [0;-1;0]
+mover_fk(mover_ik(t))
+
+t = [0;0;-1]
+mover_fk(mover_ik(t))
+
+t = [1;1;0]
+mover_fk(mover_ik(t))
+
+t = [-1;-1;0]
+mover_fk(mover_ik(t))
+
+t = [1;0;1]
+mover_fk(mover_ik(t))
+
+t = [-1;0;-1]
+mover_fk(mover_ik(t))
+
+t = [0;-1;-1]
+mover_fk(mover_ik(t))
+
+t = [0;1;1]
+mover_fk(mover_ik(t))

--- a/ridgeback_control/test/odometry_test.cpp
+++ b/ridgeback_control/test/odometry_test.cpp
@@ -1,0 +1,155 @@
+#include <mecanum_drive_controller/odometry.h>
+#include <mecanum_drive_controller/mecanum_drive_controller.h>
+#include <gtest/gtest.h>
+
+namespace mecanum_drive_controller {
+namespace {
+
+
+TEST(MecanumOdometryTest, normalKinematicsX)
+{
+  // Uses the same geometry as the IK tests in the controller.
+  double r = 0.1;
+  double a = 1;
+  double b = 0.5;
+  Odometry::BodyVelocities velocities;
+
+  velocities = Odometry::calculateKinematicsNormal(10, 10, 10, 10, r, a, b);
+  EXPECT_FLOAT_EQ(1.0, velocities.linearX);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearY);
+  EXPECT_FLOAT_EQ(0.0, velocities.angular);
+
+  velocities = Odometry::calculateKinematicsNormal(-10, -10, -10, -10, r, a, b);
+  EXPECT_FLOAT_EQ(-1.0, velocities.linearX);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearY);
+  EXPECT_FLOAT_EQ(0.0, velocities.angular);
+}
+
+TEST(MecanumOdometryTest, normalKinematicsY)
+{
+    // Uses the same geometry as the IK tests in the controller.
+    double r = 0.1;
+    double a = 1;
+    double b = 0.5;
+    Odometry::BodyVelocities velocities;
+
+    velocities = Odometry::calculateKinematicsNormal(-10, 10, -10, 10, r, a, b);
+    EXPECT_FLOAT_EQ(0.0, velocities.linearX);
+    EXPECT_FLOAT_EQ(1.0, velocities.linearY);
+    EXPECT_FLOAT_EQ(0.0, velocities.angular);
+
+    velocities = Odometry::calculateKinematicsNormal(10, -10, 10, -10, r, a, b);
+    EXPECT_FLOAT_EQ(0.0, velocities.linearX);
+    EXPECT_FLOAT_EQ(-1.0, velocities.linearY);
+    EXPECT_FLOAT_EQ(0.0, velocities.angular);
+}
+
+TEST(MecanumOdometryTest, normalKinematicsAngular)
+{
+  // Uses the same geometry as the IK tests in the controller.
+  double r = 0.1;
+  double a = 1;
+  double b = 0.5;
+  Odometry::BodyVelocities velocities;
+
+  velocities = Odometry::calculateKinematicsNormal(-15, -15, 15, 15, r, a, b);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearX);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearY);
+  EXPECT_FLOAT_EQ(1.0, velocities.angular);
+
+  velocities = Odometry::calculateKinematicsNormal(15, 15, -15, -15, r, a, b);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearX);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearY);
+  EXPECT_FLOAT_EQ(-1.0, velocities.angular);
+}
+
+TEST(MecanumOdometryTest, flippedKinematicsRoundTrip)
+{
+  // Uses the same geometry as the IK tests in the controller.
+  double r = 0.1;
+  double a = 0.5;
+  double b = 1;
+
+  Odometry::BodyVelocities body_velocities;
+  MecanumDriveController::WheelVelocities wheel_velocities;
+  wheel_velocities = MecanumDriveController::calculateIkFlipped(1, 0, 0, r, a, b);
+  body_velocities = Odometry::calculateKinematicsFlipped(wheel_velocities.w0_vel,
+                                                         wheel_velocities.w1_vel,
+                                                         wheel_velocities.w2_vel,
+                                                         wheel_velocities.w3_vel,
+                                                         r, a, b);
+  EXPECT_FLOAT_EQ(1.0, body_velocities.linearX);
+  EXPECT_FLOAT_EQ(0.0, body_velocities.linearY);
+  EXPECT_FLOAT_EQ(0.0, body_velocities.angular);
+
+  wheel_velocities = MecanumDriveController::calculateIkFlipped(-1, 1, 0.1, r, a, b);
+  body_velocities = Odometry::calculateKinematicsFlipped(wheel_velocities.w0_vel,
+                                                         wheel_velocities.w1_vel,
+                                                         wheel_velocities.w2_vel,
+                                                         wheel_velocities.w3_vel,
+                                                         r, a, b);
+  EXPECT_FLOAT_EQ(-1, body_velocities.linearX);
+  EXPECT_FLOAT_EQ(1, body_velocities.linearY);
+  EXPECT_FLOAT_EQ(0.1, body_velocities.angular);
+}
+
+TEST(MecanumOdometryTest, flippedKinematicsX)
+{
+  // Uses the same geometry as the IK tests in the controller.
+  double r = 0.1;
+  double a = 0.5;
+  double b = 1;
+  Odometry::BodyVelocities velocities;
+
+  velocities = Odometry::calculateKinematicsFlipped(10, 10, -10, -10, r, a, b);
+  EXPECT_FLOAT_EQ(1.0, velocities.linearX);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearY);
+  EXPECT_FLOAT_EQ(0.0, velocities.angular);
+
+  velocities = Odometry::calculateKinematicsFlipped(-10, -10, 10, 10, r, a, b);
+  EXPECT_FLOAT_EQ(-1.0, velocities.linearX);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearY);
+  EXPECT_FLOAT_EQ(0.0, velocities.angular);
+}
+
+TEST(MecanumOdometryTest, flippedKinematicsY)
+{
+  // Uses the same geometry as the IK tests in the controller.
+  double r = 0.1;
+  double a = 0.5;
+  double b = 1;
+  Odometry::BodyVelocities velocities;
+
+  velocities = Odometry::calculateKinematicsFlipped(-10, 10, 10, -10, r, a, b);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearX);
+  EXPECT_FLOAT_EQ(1.0, velocities.linearY);
+  EXPECT_FLOAT_EQ(0.0, velocities.angular);
+
+  velocities = Odometry::calculateKinematicsFlipped(10, -10, -10, 10, r, a, b);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearX);
+  EXPECT_FLOAT_EQ(-1.0, velocities.linearY);
+  EXPECT_FLOAT_EQ(0.0, velocities.angular);
+}
+
+TEST(MecanumOdometryTest, flippedKinematicsAngular)
+{
+  // Uses the same geometry as the IK tests in the controller.
+  double r = 0.1;
+  double a = 0.5;
+  double b = 1;
+  Odometry::BodyVelocities velocities;
+
+  velocities = Odometry::calculateKinematicsFlipped(-5, -5, -5, -5, r, a, b);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearX);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearY);
+  EXPECT_FLOAT_EQ(1.0, velocities.angular);
+
+  velocities = Odometry::calculateKinematicsFlipped(5, 5, 5, 5, r, a, b);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearX);
+  EXPECT_FLOAT_EQ(0.0, velocities.linearY);
+  EXPECT_FLOAT_EQ(-1.0, velocities.angular);
+}
+
+} // anom namespace
+} // mecanum_drive_controller namespace
+


### PR DESCRIPTION
Sorry did not realize that https://github.com/iron-ox/ridgeback/pull/2 was already merged.

This adds support for the 'flipped' forward kinematics so that the odometry calculation is done correctly. I've added tests to make sure that the 'round trip' between forward and inverse kinematics works.

It's important to note that some values of wheel velocities might transform the forward system into a over determined system, breaking the odometry calculation. I don't think that this will happen with any commanded body velocity, but might happen if an encoder is broken for example.
