### PR TITLE
Add catkin export target to make sure msgs are built first

### DIFF
--- a/ridgeback_control/CMakeLists.txt
+++ b/ridgeback_control/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories(
 )
 
 add_library(mecanum_drive_controller ${mecanum_drive_controller_headers} ${mecanum_drive_controller_sources})
+add_dependencies(mecanum_drive_controller ${catkin_EXPORTED_TARGETS})
 target_link_libraries(mecanum_drive_controller ${catkin_LIBRARIES})
 
 install(TARGETS mecanum_drive_controller


### PR DESCRIPTION
@jonbinney  I also need to add `${catkin_EXPORTED_TARGETS}` to make sure the `ridgeback_msgs` are built first. It's complaining on our iron_ox branch. 